### PR TITLE
XRECORD: renamed dxf_xrecord to dxf_xrecord_struct.

### DIFF
--- a/src/xrecord.h
+++ b/src/xrecord.h
@@ -56,7 +56,7 @@ extern "C" {
  * \version According to DXF R14.
  */
 typedef struct
-dxf_xrecord
+dxf_xrecord_struct
 {
         /* Members common for all DXF objects. */
         int id_code;


### PR DESCRIPTION
Signed-off-by: bert <bert.timmerman@xs4all.nl>

Add text here ;-)
