### PR TITLE
Investigate segfault

### DIFF
--- a/src/entities.c
+++ b/src/entities.c
@@ -118,7 +118,7 @@ dxf_entities_init
         if (entities == NULL)
         {
               fprintf (stderr,
-                (_("Error in %s () could not allocate memory for a DxfEntities struct.\n")),
+                (_("Error in %s () could not allocate memory.\n")),
                 __FUNCTION__);
               return (NULL);
         }

--- a/src/file.c
+++ b/src/file.c
@@ -76,6 +76,7 @@ dxf_file_read
         }
         while (fp)
         {
+                memset(temp_string, 0, sizeof(temp_string));
                 dxf_read_line (temp_string, fp);
                 if (strcmp (temp_string, "999") == 0)
                 {

--- a/src/header.c
+++ b/src/header.c
@@ -1408,12 +1408,12 @@ dxf_header_read_parser
                                          &header->AcadMaintVer,
                                          acad_version_number > AC1014);
         dxf_return(ret);
-                
+
         ret = dxf_header_read_parse_string (fp, temp_string, "$DWGCODEPAGE",
                                             &header->DWGCodePage,
                                             acad_version_number >= AC1012);
         dxf_return(ret);
-        
+
         ret = dxf_header_read_parse_n_double (fp, temp_string, "$INSBASE",
                                               TRUE,
                                               3,
@@ -1789,14 +1789,14 @@ dxf_header_read_parser
                                               TRUE,
                                               2,
                                               &header->PLimMin.x0,
-                                              header->PLimMin.y0);
+                                              &header->PLimMin.y0);
         dxf_return(ret);
     
         ret = dxf_header_read_parse_n_double (fp, temp_string, "$PLIMMAX",
                                               TRUE,
                                               2,
                                               &header->PLimMax.x0,
-                                              header->PLimMax.y0);
+                                              &header->PLimMax.y0);
         dxf_return(ret);
         /*
         fprintf (fp, "  9\n$UNITMODE\n 70\n%i\n", header->UnitMode);
@@ -1908,10 +1908,10 @@ dxf_header_read
         dxf_return_val_if_fail (ret, FALSE);
         /* turn the acad_version into an integer */
         acad_version_number = dxf_header_acad_version_from_string (header->AcadVer);
-    
+
         /*! \todo FIXME: stores the autocad version as int */
         header->_AcadVer = acad_version_number;
-    
+
         /* a loop to read all the header with no particulary order */
         while (!feof (fp->fp))
         {
@@ -1935,7 +1935,7 @@ dxf_header_read
                           (_("[File: %s: line: %d] read_header :: Section Ended.\n")),
                           __FILE__, __LINE__);
 #endif
-                }        
+                }
         }
 #if DEBUG
         DXF_DEBUG_END

--- a/src/section.c
+++ b/src/section.c
@@ -51,7 +51,7 @@ dxf_section_read
 #if DEBUG
         DXF_DEBUG_BEGIN
 #endif
-        char *temp_string = NULL;
+        char temp_string[DXF_MAX_STRING_LENGTH];
         DxfHeader dxf_header;
         DxfBlock dxf_block;
         char *dxf_entities_list = NULL;
@@ -62,15 +62,15 @@ dxf_section_read
                 fprintf (stderr,
                   (_("Error in %s () a NULL file pointer was passed.\n")),
                   __FUNCTION__);
-                /* Clean up. */
-                free (temp_string);
                 return (EXIT_FAILURE);
         }
+        memset(temp_string, 0, sizeof(temp_string));
         dxf_read_line (temp_string, fp);
         if (strcmp (temp_string, "2") == 0)
         {
                 while (!feof (fp->fp))
                 {
+                        memset(temp_string, 0, sizeof(temp_string));
                         dxf_read_line (temp_string, fp);
                         if (strcmp (temp_string, "HEADER") == 0)
                         {
@@ -125,8 +125,6 @@ dxf_section_read
                   (_("Warning in %s () unexpected string encountered while reading line %d from: %s.\n")),
                   __FUNCTION__, fp->line_number, fp->filename);
         }
-        /* Clean up. */
-        free (temp_string);
 #if DEBUG
         DXF_DEBUG_END
 #endif

--- a/tests/tests.c
+++ b/tests/tests.c
@@ -41,7 +41,7 @@
  */
 int main (void)
 {
-    if (dxf_file_read ("../examples/qcad-example_R2000.dxf"))
+    if (dxf_file_read ("../../examples/qcad-example_R2000.dxf"))
         fprintf (stdout, "TESTS: R2000 exited with error\n");
     else
         fprintf (stdout, "TESTS: R2000 exited with no error\n");


### PR DESCRIPTION
This is not related to an open issue.

The automated test caused a segment violation error upon running. This primarily was due to some values being treated as pointers. I have edited the source to guard against such segfaults.

Now, instead of crashing, the program runs indefinitely. I'll investigate that as well.