### PR TITLE
Potential fix for code scanning alert no. 2: Incorrect return-value check for a 'scanf'-like function

### DIFF
--- a/src/util.c
+++ b/src/util.c
@@ -2498,16 +2498,25 @@ dxf_read_line (char * temp_string, DxfFile *fp)
         int ret;
 
         ret = fscanf (fp->fp, "%[^\n]\n", temp_string);
-        if (ferror (fp->fp))
+        if (ret == EOF)
         {
-                fprintf (stderr,
-                  (_("Error: while reading from: %s in line: %d.\n")),
-                  fp->filename, fp->line_number);
+                if (ferror (fp->fp))
+                {
+                        fprintf (stderr,
+                          (_("Error: while reading from: %s in line: %d.\n")),
+                          fp->filename, fp->line_number);
+                }
+                /* Return failure on EOF or error. */
                 return (EXIT_FAILURE);
         }
-        if (ret)
+        if (ret == 1)
         {
                 fp->line_number++;
+        }
+        else
+        {
+                /* No items read; treat as a failure. */
+                return (EXIT_FAILURE);
         }
 #if DEBUG
         DXF_DEBUG_END


### PR DESCRIPTION
Potential fix for [https://github.com/bert/libdxf/security/code-scanning/2](https://github.com/bert/libdxf/security/code-scanning/2)

To fix the problem, the code should explicitly compare the return value of `fscanf` against the expected number of matches (in this case, likely 1, since there is just one format specifier). It must also detect and handle `EOF` distinctly. Specifically, after calling `fscanf (fp->fp, "%[^\n]\n", temp_string)`, the return value should be compared: if it is 1, the scan succeeded; if 0, the input did not match; if `EOF` (-1), an error or end of file occurred. The function should only increment `fp->line_number` on a successful read, and should consider returning `EXIT_FAILURE` or handling the error otherwise on `EOF` or other incorrect return values.

Only the code inside the function `dxf_read_line` needs to be changed, specifically the region that calls and checks the return value from `fscanf`.

No new imports or headers are necessary; just the logic of return value handling changes.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
